### PR TITLE
Partial Fix:  GH: #76219 Disabling process of PhysicsBody2D and conta…

### DIFF
--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -179,10 +179,10 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 	locked = true;
 
 	if (body_in) {
-		if (!E) {
+		if (!E && !body_map.has(objid)) {
 			E = body_map.insert(objid, BodyState());
 			E->value.rid = p_body;
-			E->value.rc = 0;
+			E->value.rc = 1;
 			E->value.in_tree = node && node->is_inside_tree();
 			if (node) {
 				node->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_body_enter_tree).bind(objid));
@@ -192,7 +192,6 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 				}
 			}
 		}
-		E->value.rc++;
 		if (node) {
 			E->value.shapes.insert(ShapePair(p_body_shape, p_area_shape));
 		}
@@ -275,10 +274,10 @@ void Area2D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 	locked = true;
 
 	if (area_in) {
-		if (!E) {
+		if (!E && !area_map.has(objid)) {
 			E = area_map.insert(objid, AreaState());
 			E->value.rid = p_area;
-			E->value.rc = 0;
+			E->value.rc = 1;
 			E->value.in_tree = node && node->is_inside_tree();
 			if (node) {
 				node->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area2D::_area_enter_tree).bind(objid));
@@ -288,7 +287,6 @@ void Area2D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 				}
 			}
 		}
-		E->value.rc++;
 		if (node) {
 			E->value.shapes.insert(AreaShapePair(p_area_shape, p_self_shape));
 		}

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -234,10 +234,10 @@ void Area3D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 	locked = true;
 
 	if (body_in) {
-		if (!E) {
+		if (!E && !body_map.has(objid)) {
 			E = body_map.insert(objid, BodyState());
 			E->value.rid = p_body;
-			E->value.rc = 0;
+			E->value.rc = 1;
 			E->value.in_tree = node && node->is_inside_tree();
 			if (node) {
 				node->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area3D::_body_enter_tree).bind(objid));
@@ -247,7 +247,6 @@ void Area3D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 				}
 			}
 		}
-		E->value.rc++;
 		if (node) {
 			E->value.shapes.insert(ShapePair(p_body_shape, p_area_shape));
 		}
@@ -423,10 +422,10 @@ void Area3D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 	locked = true;
 
 	if (area_in) {
-		if (!E) {
+		if (!E && !area_map.has(objid)) {
 			E = area_map.insert(objid, AreaState());
 			E->value.rid = p_area;
-			E->value.rc = 0;
+			E->value.rc = 1;
 			E->value.in_tree = node && node->is_inside_tree();
 			if (node) {
 				node->connect(SceneStringNames::get_singleton()->tree_entered, callable_mp(this, &Area3D::_area_enter_tree).bind(objid));
@@ -436,7 +435,6 @@ void Area3D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 				}
 			}
 		}
-		E->value.rc++;
 		if (node) {
 			E->value.shapes.insert(AreaShapePair(p_area_shape, p_self_shape));
 		}


### PR DESCRIPTION
…ining Area2D on same frame will make area register body as entered forever

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
